### PR TITLE
Use KMS Keys as S3 Encryption Method

### DIFF
--- a/store/s3store.go
+++ b/store/s3store.go
@@ -21,8 +21,6 @@ const (
 	MaximumVersions = 100
 	// deprecated
 	BucketEnvVar = "CHAMBER_S3_BUCKET"
-
-	latestObjectName = "__latest.json"
 )
 
 // secretObject is the serialized format for storing secrets
@@ -380,7 +378,7 @@ func (s *S3Store) puts3raw(path string, contents []byte) error {
 }
 
 func (s *S3Store) readLatest(service string) (latest, error) {
-	path := fmt.Sprintf("%s/%s", service, latestObjectName)
+	path := fmt.Sprintf("%s/%s_latest.json", service, s.latestFileKeyNameByKMSKey())
 
 	getObjectInput := &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
@@ -411,8 +409,12 @@ func (s *S3Store) readLatest(service string) (latest, error) {
 	return index, nil
 }
 
+func (s *S3Store) latestFileKeyNameByKMSKey() string {
+	return strings.Replace(s.KMSKey(), "/", "_", -1)
+}
+
 func (s *S3Store) writeLatest(service string, index latest) error {
-	path := fmt.Sprintf("%s/%s", service, latestObjectName)
+	path := fmt.Sprintf("%s/%s_latest.json", service, s.latestFileKeyNameByKMSKey())
 
 	raw, err := json.Marshal(index)
 	if err != nil {


### PR DESCRIPTION
Previously we were using AWS Parameter Store. However after hitting AWS Rate Limiting on Parameter Store and being refused a limit increase we decided to switch the Chamber S3 Backend. However, a major point of difference between the SSM Backend and the S3 Backend is that the SSM Backend supports AWS KMS Keys.

This PR switches from using AES256 Encryption (read the one key stored by all S3 servers) to using KMS Keys for Encryption (read specific keys that you create via AWS KMS Service, AWS Manages the KMS key but you have control over disabling them when they become compromised and restricting access to them via IAM Roles).

Along the way, I ran into the issue that Chamber is caching the keys and values for each service in a `__latest.json` file. To make the KMS Encryption worthwhile, I changed the `__latest.json` be a "latest" file per KMS Key. This differs slightly from the behavior of the SSM Store backend when the user doesn't provide the `CHAMBER_KMS_KEY_ALIAS` environment variable. In the SSM backend, you as the user are able to read any secrets which you have the KMS Key for. However In the S3 Version (with the changes that I've made, you're not able to see secrets the secrets for a KMS key without providing `CHAMBER_KMS_KEY_ALIAS` environment variable). 

Currently, the S3 Bucket looks like:
```
- service-name:
   - __latest.json
   - Key Named JSON File (eg, database_name.json)
   - Key Named JSON File (eg, database_password.json)
   - Key Named JSON File (eg, database_username.json)
- service-name:
   - __latest.json
   - Key Named JSON File (eg, database_name.json)
   - Key Named JSON File (eg, database_password.json)
   - Key Named JSON File (eg, database_username.json)
```

With these changes:
```
- service-name:
   - __latest.json
   - Key Named JSON File (eg, database_name.json)
   - Key Named JSON File (eg, database_password.json)
   - Key Named JSON File (eg, database_username.json)
- service-name:
   - alias_default_parameter_store_key__latest.json
   - alias_very_secret_kms_key__latest.json
   - Key Named JSON File (eg, database_name.json)
   - Key Named JSON File (eg, database_password.json)
   - Key Named JSON File (eg, database_username.json)
```

The pitfalls of the current implementation are:
- Currently, you must supply the CHAMBER_KMS_KEY_ALIAS when performing any operation.
- You're only able to see the secrets written by the KMS Key you provide as `CHAMBER_KMS_KEY_ALIAS` even if you're able to read secrets written by other KMS Keys.