### PR TITLE
Use kms for s3 storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,29 @@ To configure chamber to use the S3 backend, use `chamber -b s3 --backend-s3-buck
 
 This feature is experimental, and not currently meant for production work.
 
+### S3 Backend using KMS Key Encryption (Experimental)
+
+This backend is similar to the S3 Backend but uses KMS Key Encryption to encrypt your documents at rest, similar to the SSM Backend which encrypts your secrets at rest. You can read how S3 Encrypts documents with KMS [here](https://docs.aws.amazon.com/kms/latest/developerguide/services-s3.html).
+
+The highlights of SSE-KMS are:
+- You can choose to create and manage encryption keys yourself, or you can choose to use your default service key uniquely generated on a customer by service by region level.
+- The ETag in the response is not the MD5 of the object data.
+- The data keys used to encrypt your data are also encrypted and stored alongside the data they protect.
+- Auditable master keys can be created, rotated, and disabled from the AWS KMS console.
+- The security controls in AWS KMS can help you meet encryption-related compliance requirements.
+Source https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
+
+To configure chamber to use the S3 backend, use `chamber -b s3-kms --backend-s3-bucket=mybucket`.  You must also supply an environment variable of the KMS Key Alias to use CHAMBER_KMS_KEY_ALIAS, by default "alias/parameter_store_key" will be used.
+
+Preferably, this bucket should reject uploads that do not set the server side encryption header ([see this doc for details how](https://aws.amazon.com/blogs/security/how-to-prevent-uploads-of-unencrypted-objects-to-amazon-s3/))
+
+
+When changing secrets between KMS Keys, you must first delete the Chamber secret with the existing KMS Key, then write it again with new KMS Key.
+
+If services contain multiple KMS Keys, `chamber list` and `chamber exec` will only show Chamber secrets encrypted with KMS Keys you have access to.
+
+This feature is experimental, and not currently meant for production work.
+
 ## Null Backend (experimental)
 
 If it's preferred to not use any backend at all, use `chamber -b null`. Doing so will forward existing ENV variables as if Chamber is not in between.

--- a/store/s3store.go
+++ b/store/s3store.go
@@ -21,8 +21,6 @@ const (
 	MaximumVersions = 100
 	// deprecated
 	BucketEnvVar = "CHAMBER_S3_BUCKET"
-
-	latestObjectName = "__latest.json"
 )
 
 // secretObject is the serialized format for storing secrets
@@ -380,7 +378,7 @@ func (s *S3Store) puts3raw(path string, contents []byte) error {
 }
 
 func (s *S3Store) readLatest(service string) (latest, error) {
-	path := fmt.Sprintf("%s/%s", service, latestObjectName)
+	path := fmt.Sprintf("%s/%s_latest.json", service, s.latestFileKeyNameByKMSKey())
 
 	getObjectInput := &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
@@ -411,8 +409,12 @@ func (s *S3Store) readLatest(service string) (latest, error) {
 	return index, nil
 }
 
+func (s *S3Store) latestFileKeyNameByKMSKey() string {
+	return strings.Replace(s.KMSKey(), "/", "_", -1)
+}
+
 func (s *S3Store) writeLatest(service string, index latest) error {
-	path := fmt.Sprintf("%s/%s", service, latestObjectName)
+	path := fmt.Sprintf("%s/%s_latest.json", service, s.latestFileKeyNameByKMSKey())
 
 	raw, err := json.Marshal(index)
 	if err != nil {

--- a/store/s3store.go
+++ b/store/s3store.go
@@ -116,7 +116,7 @@ func (s *S3Store) Write(id SecretId, value string) error {
 
 	if val, ok := index.Latest[id.Key]; ok {
 		if val.KMSAlias != s.KMSKey() {
-			return errors.New("You're attempting to write a Chamber key with a different KMS Key to the one it currently uses. Instead delete the existing chamber key using the old KMS key and write a the secret using the new KMS Key.")
+			return errors.New(fmt.Sprintf("You're attempting to write a Chamber key with a different KMS Key to the one it currently uses. Instead delete the existing chamber key using the current KMS key (%s) and write a the secret using the new KMS Key.", val.KMSAlias))
 		}
 	}
 
@@ -303,7 +303,7 @@ func (s *S3Store) Delete(id SecretId) error {
 
 	if val, ok := index.Latest[id.Key]; ok {
 		if val.KMSAlias != s.KMSKey() {
-			return errors.New("You're attempting to delete a Chamber key with a different KMS Key to the one it currently uses. Please use the current KMS Key.")
+			return errors.New(fmt.Sprintf("You're attempting to delete a Chamber key with a different KMS Key to the one it currently uses. Please use the current KMS Key (%s).", val.KMSAlias))
 		}
 	}
 

--- a/store/s3storeKMS.go
+++ b/store/s3storeKMS.go
@@ -8,66 +8,61 @@ import (
 	"os"
 	"sort"
 	"time"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/pkg/errors"
 )
-
-const (
-	MaximumVersions = 100
-	// deprecated
-	BucketEnvVar = "CHAMBER_S3_BUCKET"
-
-	latestObjectName = "__latest.json"
-)
-
-// secretObject is the serialized format for storing secrets
-// as an s3 object
-type secretObject struct {
-	Service string                `json:"service"`
-	Key     string                `json:"key"`
-	Values  map[int]secretVersion `json:"values"`
-}
-
-// secretVersion holds all the metadata for a specific version
-// of a secret
-type secretVersion struct {
-	Created   time.Time `json:"created"`
-	CreatedBy string    `json:"created_by"`
-	Version   int       `json:"version"`
-	Value     string    `json:"value"`
-}
 
 // latest is used to keep a single object in s3 with all of the
 // most recent values for the given service's secrets.  Keeping this
 // in a single s3 object allows us to use a single s3 GetObject
 // for ListRaw (and thus chamber exec).
-type latest struct {
-	Latest map[string]string `json:"latest"`
+type LatestIndexFile struct {
+	Latest map[string]LatestValue `json:"latest"`
 }
 
-var _ Store = &S3Store{}
+type LatestValue struct {
+	Version   int       `json:"version"`
+	Value     string    `json:"value"`
+	KMSAlias  string    `json:"KMSAlias"`
+}
 
-type S3Store struct {
+var _ Store = &S3KMSStore{}
+
+type S3KMSStore struct {
 	svc    s3iface.S3API
 	stsSvc *sts.STS
 	bucket string
 }
 
-// Deprecated; use NewS3StoreWithBucket instead
-func NewS3Store(numRetries int) (*S3Store, error) {
+// Deprecated; use NewS3KMSStoreWithBucket instead
+func NewS3KMSStore(numRetries int) (*S3KMSStore, error) {
 	bucket, ok := os.LookupEnv(BucketEnvVar)
 	if !ok {
 		return nil, fmt.Errorf("Must set %s for s3 backend", BucketEnvVar)
 	}
 
-	return NewS3StoreWithBucket(numRetries, bucket)
+	return NewS3KMSStoreWithBucket(numRetries, bucket)
 }
 
-func NewS3StoreWithBucket(numRetries int, bucket string) (*S3Store, error) {
+func(s *S3KMSStore) KMSKey() string {
+	fromEnv, ok := os.LookupEnv("CHAMBER_KMS_KEY_ALIAS")
+	if !ok {
+		return DefaultKeyID
+	}
+	if !strings.HasPrefix(fromEnv, "alias/") {
+		return fmt.Sprintf("alias/%s", fromEnv)
+	}
+
+	return fromEnv
+}
+
+func NewS3KMSStoreWithBucket(numRetries int, bucket string) (*S3KMSStore, error) {
 	session, region, err := getSession(numRetries)
 	if err != nil {
 		return nil, err
@@ -83,17 +78,23 @@ func NewS3StoreWithBucket(numRetries int, bucket string) (*S3Store, error) {
 		Region:     region,
 	})
 
-	return &S3Store{
+	return &S3KMSStore{
 		svc:    svc,
 		stsSvc: stsSvc,
 		bucket: bucket,
 	}, nil
 }
 
-func (s *S3Store) Write(id SecretId, value string) error {
+func (s *S3KMSStore) Write(id SecretId, value string) error {
 	index, err := s.readLatest(id.Service)
 	if err != nil {
 		return err
+	}
+
+	if val, ok := index.Latest[id.Key]; ok {
+		if val.KMSAlias != s.KMSKey() {
+			return errors.New(fmt.Sprintf("You're attempting to write a Chamber key with a different KMS Key to the one it currently uses. Instead delete the existing chamber key using the current KMS key (%s) and then write the secret using the new KMS Key.", val.KMSAlias))
+		}
 	}
 
 	objPath := getObjectPath(id)
@@ -134,7 +135,8 @@ func (s *S3Store) Write(id SecretId, value string) error {
 
 	putObjectInput := &s3.PutObjectInput{
 		Bucket:               aws.String(s.bucket),
-		ServerSideEncryption: aws.String(s3.ServerSideEncryptionAes256),
+		ServerSideEncryption: aws.String(s3.ServerSideEncryptionAwsKms),
+		SSEKMSKeyId:          aws.String(s.KMSKey()),
 		Key:                  aws.String(objPath),
 		Body:                 bytes.NewReader(contents),
 	}
@@ -145,11 +147,15 @@ func (s *S3Store) Write(id SecretId, value string) error {
 		return err
 	}
 
-	index.Latest[id.Key] = value
+	index.Latest[id.Key] = LatestValue {
+		Version: thisVersion,
+		Value: value,
+		KMSAlias: s.KMSKey(),
+	}
 	return s.writeLatest(id.Service, index)
 }
 
-func (s *S3Store) Read(id SecretId, version int) (Secret, error) {
+func (s *S3KMSStore) Read(id SecretId, version int) (Secret, error) {
 	obj, ok, err := s.readObjectById(id)
 	if err != nil {
 		return Secret{}, err
@@ -178,7 +184,7 @@ func (s *S3Store) Read(id SecretId, version int) (Secret, error) {
 	}, nil
 }
 
-func (s *S3Store) List(service string, includeValues bool) ([]Secret, error) {
+func (s *S3KMSStore) List(service string, includeValues bool) ([]Secret, error) {
 	index, err := s.readLatest(service)
 	if err != nil {
 		return []Secret{}, err
@@ -219,7 +225,7 @@ func (s *S3Store) List(service string, includeValues bool) ([]Secret, error) {
 	return secrets, nil
 }
 
-func (s *S3Store) ListRaw(service string) ([]RawSecret, error) {
+func (s *S3KMSStore) ListRaw(service string) ([]RawSecret, error) {
 	index, err := s.readLatest(service)
 	if err != nil {
 		return []RawSecret{}, err
@@ -229,7 +235,7 @@ func (s *S3Store) ListRaw(service string) ([]RawSecret, error) {
 	for key, value := range index.Latest {
 		s := RawSecret{
 			Key:   fmt.Sprintf("/%s/%s", service, key),
-			Value: value,
+			Value: value.Value,
 		}
 		secrets = append(secrets, s)
 
@@ -238,7 +244,7 @@ func (s *S3Store) ListRaw(service string) ([]RawSecret, error) {
 	return secrets, nil
 }
 
-func (s *S3Store) History(id SecretId) ([]ChangeEvent, error) {
+func (s *S3KMSStore) History(id SecretId) ([]ChangeEvent, error) {
 	obj, ok, err := s.readObjectById(id)
 	if err != nil {
 		return []ChangeEvent{}, err
@@ -266,10 +272,16 @@ func (s *S3Store) History(id SecretId) ([]ChangeEvent, error) {
 	return events, nil
 }
 
-func (s *S3Store) Delete(id SecretId) error {
+func (s *S3KMSStore) Delete(id SecretId) error {
 	index, err := s.readLatest(id.Service)
 	if err != nil {
 		return err
+	}
+
+	if val, ok := index.Latest[id.Key]; ok {
+		if val.KMSAlias != s.KMSKey() {
+			return errors.New(fmt.Sprintf("You're attempting to delete a Chamber key with a different KMS Key to the one it currently uses. Please use the current KMS Key (%s).", val.KMSAlias))
+		}
 	}
 
 	if _, ok := index.Latest[id.Key]; ok {
@@ -286,7 +298,7 @@ func (s *S3Store) Delete(id SecretId) error {
 // getCurrentUser uses the STS API to get the current caller identity,
 // so that secret value changes can be correctly attributed to the right
 // aws user/role
-func (s *S3Store) getCurrentUser() (string, error) {
+func (s *S3KMSStore) getCurrentUser() (string, error) {
 	resp, err := s.stsSvc.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 	if err != nil {
 		return "", err
@@ -295,12 +307,12 @@ func (s *S3Store) getCurrentUser() (string, error) {
 	return *resp.Arn, nil
 }
 
-func (s *S3Store) deleteObjectById(id SecretId) error {
+func (s *S3KMSStore) deleteObjectById(id SecretId) error {
 	path := getObjectPath(id)
 	return s.deleteObject(path)
 }
 
-func (s *S3Store) deleteObject(path string) error {
+func (s *S3KMSStore) deleteObject(path string) error {
 	deleteObjectInput := &s3.DeleteObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(path),
@@ -310,7 +322,7 @@ func (s *S3Store) deleteObject(path string) error {
 	return err
 }
 
-func (s *S3Store) readObject(path string) (secretObject, bool, error) {
+func (s *S3KMSStore) readObject(path string) (secretObject, bool, error) {
 	getObjectInput := &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(path),
@@ -347,15 +359,16 @@ func (s *S3Store) readObject(path string) (secretObject, bool, error) {
 
 }
 
-func (s *S3Store) readObjectById(id SecretId) (secretObject, bool, error) {
+func (s *S3KMSStore) readObjectById(id SecretId) (secretObject, bool, error) {
 	path := getObjectPath(id)
 	return s.readObject(path)
 }
 
-func (s *S3Store) puts3raw(path string, contents []byte) error {
+func (s *S3KMSStore) puts3raw(path string, contents []byte) error {
 	putObjectInput := &s3.PutObjectInput{
 		Bucket:               aws.String(s.bucket),
-		ServerSideEncryption: aws.String(s3.ServerSideEncryptionAes256),
+		ServerSideEncryption: aws.String(s3.ServerSideEncryptionAwsKms),
+		SSEKMSKeyId:          aws.String(s.KMSKey()),
 		Key:                  aws.String(path),
 		Body:                 bytes.NewReader(contents),
 	}
@@ -364,40 +377,97 @@ func (s *S3Store) puts3raw(path string, contents []byte) error {
 	return err
 }
 
-func (s *S3Store) readLatest(service string) (latest, error) {
-	path := fmt.Sprintf("%s/%s", service, latestObjectName)
-
+func (s *S3KMSStore) readLatestFile(path string) (LatestIndexFile, error) {
 	getObjectInput := &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(path),
 	}
 
 	resp, err := s.svc.GetObject(getObjectInput)
+
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
+			if aerr.Code() == "AccessDenied" {
+				// If we're not able to read the latest index for a KMS Key then proceed like it doesn't exist.
+				// We do this because in a chamber secret folder there might be other secrets written with a KMS Key that you don't have access to.
+				return LatestIndexFile{Latest: map[string]LatestValue{}}, nil
+			}
+
 			if aerr.Code() == s3.ErrCodeNoSuchKey {
 				// Index doesn't exist yet, return an empty index
-				return latest{Latest: map[string]string{}}, nil
+				return LatestIndexFile{Latest: map[string]LatestValue{}}, nil
 			}
 		}
-		return latest{}, err
+		return LatestIndexFile{}, err
 	}
 
 	raw, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return latest{}, err
+		return LatestIndexFile{}, err
 	}
 
-	var index latest
+	var index LatestIndexFile
 	if err := json.Unmarshal(raw, &index); err != nil {
-		return latest{}, err
+		return LatestIndexFile{}, err
 	}
 
 	return index, nil
 }
 
-func (s *S3Store) writeLatest(service string, index latest) error {
-	path := fmt.Sprintf("%s/%s", service, latestObjectName)
+func (s *S3KMSStore) readLatest(service string) (LatestIndexFile, error) {
+	// Create an empty latest, this will be used to merge together the various KMS Latest Files
+	latestResult := LatestIndexFile{Latest: map[string]LatestValue{}}
+
+	// List all the files that are prefixed with kms and use them as latest.json files for that KMS Key.
+	params := &s3.ListObjectsInput{
+		Bucket:     aws.String(s.bucket),
+		Prefix:     aws.String(fmt.Sprintf("%s/kms", service)),
+	}
+
+	err := s.svc.ListObjectsPages(params, func(page *s3.ListObjectsOutput, lastPage bool) bool {
+		for index := range page.Contents {
+			key_name := *page.Contents[index].Key
+			result, err := s.readLatestFile(key_name)
+			if err != nil {
+				// Panic if we encounter an error reading the index (keeping in mind it handles AccessDenied).
+				panic(fmt.Sprintf("Error reading latest index for KMS Key (%s): %s", key_name, err))
+			}
+			// Check if the chamber key already exists in the index.Latest map.
+			// Prefer the most recent version.
+			for k, v := range result.Latest {
+				if val, ok := latestResult.Latest[k]; ok {
+					if(val.Version > v.Version) {
+						latestResult.Latest[k] = val
+					} else {
+						latestResult.Latest[k] = v
+					}
+				} else {
+					latestResult.Latest[k] = v
+				}
+			}
+		}
+
+		return !lastPage
+	})
+
+	if err != nil {
+		return latestResult, err
+	}
+
+	return latestResult, nil
+}
+
+func (s *S3KMSStore) latestFileKeyNameByKMSKey() string {
+	return fmt.Sprintf("kms_%s__latest.json", strings.Replace(s.KMSKey(), "/", "_", -1))
+}
+
+func (s *S3KMSStore) writeLatest(service string, index LatestIndexFile) error {
+	path := fmt.Sprintf("%s/%s", service, s.latestFileKeyNameByKMSKey())
+	for k,v := range index.Latest {
+		if v.KMSAlias != s.KMSKey() {
+			delete(index.Latest, k)
+		}
+	}
 
 	raw, err := json.Marshal(index)
 	if err != nil {
@@ -405,37 +475,4 @@ func (s *S3Store) writeLatest(service string, index latest) error {
 	}
 
 	return s.puts3raw(path, raw)
-}
-
-func stringInSlice(val string, sl []string) bool {
-	for _, v := range sl {
-		if v == val {
-			return true
-		}
-	}
-	return false
-}
-
-func getObjectPath(id SecretId) string {
-	return fmt.Sprintf("%s/%s.json", id.Service, id.Key)
-}
-
-func getLatestVersion(m map[int]secretVersion) int {
-	max := 0
-	for k := range m {
-		if k > max {
-			max = k
-		}
-	}
-	return max
-}
-
-func pruneOldVersions(m map[int]secretVersion) {
-	newest := getLatestVersion(m)
-
-	for version := range m {
-		if version < newest-MaximumVersions {
-			delete(m, version)
-		}
-	}
 }

--- a/store/s3storeKMS.go
+++ b/store/s3storeKMS.go
@@ -421,7 +421,7 @@ func (s *S3KMSStore) readLatest(service string) (LatestIndexFile, error) {
 	// List all the files that are prefixed with kms and use them as latest.json files for that KMS Key.
 	params := &s3.ListObjectsInput{
 		Bucket: aws.String(s.bucket),
-		Prefix: aws.String(fmt.Sprintf("%s/kms", service)),
+		Prefix: aws.String(fmt.Sprintf("%s/__kms", service)),
 	}
 
 	var paginationError error
@@ -466,7 +466,7 @@ func (s *S3KMSStore) readLatest(service string) (LatestIndexFile, error) {
 }
 
 func (s *S3KMSStore) latestFileKeyNameByKMSKey() string {
-	return fmt.Sprintf("kms_%s__latest.json", strings.Replace(s.KMSKey(), "/", "_", -1))
+	return fmt.Sprintf("__kms_%s__latest.json", strings.Replace(s.KMSKey(), "/", "_", -1))
 }
 
 func (s *S3KMSStore) writeLatest(service string, index LatestIndexFile) error {

--- a/store/s3storeKMS.go
+++ b/store/s3storeKMS.go
@@ -7,8 +7,8 @@ import (
 	"io/ioutil"
 	"os"
 	"sort"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -27,9 +27,9 @@ type LatestIndexFile struct {
 }
 
 type LatestValue struct {
-	Version   int       `json:"version"`
-	Value     string    `json:"value"`
-	KMSAlias  string    `json:"KMSAlias"`
+	Version  int    `json:"version"`
+	Value    string `json:"value"`
+	KMSAlias string `json:"KMSAlias"`
 }
 
 var _ Store = &S3KMSStore{}
@@ -50,7 +50,7 @@ func NewS3KMSStore(numRetries int) (*S3KMSStore, error) {
 	return NewS3KMSStoreWithBucket(numRetries, bucket)
 }
 
-func(s *S3KMSStore) KMSKey() string {
+func (s *S3KMSStore) KMSKey() string {
 	fromEnv, ok := os.LookupEnv("CHAMBER_KMS_KEY_ALIAS")
 	if !ok {
 		return DefaultKeyID
@@ -147,9 +147,9 @@ func (s *S3KMSStore) Write(id SecretId, value string) error {
 		return err
 	}
 
-	index.Latest[id.Key] = LatestValue {
-		Version: thisVersion,
-		Value: value,
+	index.Latest[id.Key] = LatestValue{
+		Version:  thisVersion,
+		Value:    value,
 		KMSAlias: s.KMSKey(),
 	}
 	return s.writeLatest(id.Service, index)
@@ -420,8 +420,8 @@ func (s *S3KMSStore) readLatest(service string) (LatestIndexFile, error) {
 
 	// List all the files that are prefixed with kms and use them as latest.json files for that KMS Key.
 	params := &s3.ListObjectsInput{
-		Bucket:     aws.String(s.bucket),
-		Prefix:     aws.String(fmt.Sprintf("%s/kms", service)),
+		Bucket: aws.String(s.bucket),
+		Prefix: aws.String(fmt.Sprintf("%s/kms", service)),
 	}
 
 	err := s.svc.ListObjectsPages(params, func(page *s3.ListObjectsOutput, lastPage bool) bool {
@@ -436,7 +436,7 @@ func (s *S3KMSStore) readLatest(service string) (LatestIndexFile, error) {
 			// Prefer the most recent version.
 			for k, v := range result.Latest {
 				if val, ok := latestResult.Latest[k]; ok {
-					if(val.Version > v.Version) {
+					if val.Version > v.Version {
 						latestResult.Latest[k] = val
 					} else {
 						latestResult.Latest[k] = v
@@ -463,7 +463,7 @@ func (s *S3KMSStore) latestFileKeyNameByKMSKey() string {
 
 func (s *S3KMSStore) writeLatest(service string, index LatestIndexFile) error {
 	path := fmt.Sprintf("%s/%s", service, s.latestFileKeyNameByKMSKey())
-	for k,v := range index.Latest {
+	for k, v := range index.Latest {
 		if v.KMSAlias != s.KMSKey() {
 			delete(index.Latest, k)
 		}


### PR DESCRIPTION
Previously we were using AWS Parameter Store. However after hitting AWS Rate Limiting on Parameter Store and being refused a limit increase we decided to switch the Chamber S3 Backend. However, a major point of difference between the SSM Backend and the S3 Backend is that the SSM Backend supports AWS KMS Keys.

This PR switches from using AES256 Encryption (read the one key stored by all S3 servers) to using KMS Keys for Encryption (read specific keys that you create via AWS KMS Service, AWS Manages the KMS key but you have control over disabling them when they become compromised and restricting access to them via IAM Roles).

Along the way, I ran into the issue that Chamber is caching the keys and values for each service in a __latest.json file. To make the KMS Encryption worthwhile, I changed the __latest.json be a "latest" file per KMS Key. This differs slightly from the behavior of the SSM Store backend when the user doesn't provide the CHAMBER_KMS_KEY_ALIAS environment variable. In the SSM backend, you as the user are able to read any secrets which you have the KMS Key for. However In the S3 Version (with the changes that I've made, you're not able to see secrets encrypted with a KMS Key that you do not have access to).

Currently, the S3 Bucket looks like:

- service-name:
   - __latest.json
   - Key Named JSON File (eg, database_name.json)
   - Key Named JSON File (eg, database_password.json)
   - Key Named JSON File (eg, database_username.json)
- service-name:
   - __latest.json
   - Key Named JSON File (eg, database_name.json)
   - Key Named JSON File (eg, database_password.json)
   - Key Named JSON File (eg, database_username.json)


With these changes:

- service-name:
  - alias_default_parameter_store_key__latest.json
   - Key Named JSON File (eg, database_name.json)
   - Key Named JSON File (eg, database_password.json)
   - Key Named JSON File (eg, database_username.json)
- service-name:
   - alias_default_parameter_store_key__latest.json
   - alias_very_secret_kms_key__latest.json
   - Key Named JSON File (eg, database_name.json)
   - Key Named JSON File (eg, database_password.json)
   - Key Named JSON File (eg, database_username.json)

Implementation Decisions:
- I've chosen to make `chamber list` not show secrets that are encrypted with KMS Keys that you do not have access to. This is because multiple KMS Keys can be used within a single chamber service and some readers will only have one key.
- `chamber write` and `chamber delete` requires CHAMBER_KMS_KEY_ALIAS to be set to the same KMS Key as an existing Chamber secret. This avoids the latest version of a secret being left encrypted in S3 after you move the secret to a new KMS key.